### PR TITLE
Make clusters VPC native by default

### DIFF
--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": [],
+  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "gke-clusters",
-    "version": "0.0.2",
+    "version": "1.0.1",
     "meta": {
         "label": "GKE clusters",
         "description": "Interact with Google Kubernetes Engine clusters",

--- a/plugin.json
+++ b/plugin.json
@@ -1,13 +1,14 @@
 {
-    "id": "gke",
-    "version": "0.0.1",
+    "id": "gke-clusters",
+    "version": "0.0.2",
     "meta": {
         "label": "GKE clusters",
         "description": "Interact with Google Kubernetes Engine clusters",
         "author": "Dataiku",
-        "icon": "icon-puzzle-piece",
+        "icon": "icon-cloud",
         "licenseInfo": "Apache Software License",
-        "url": "https://www.dataiku.com/dss/plugins/info/gke.html",
-        "tags": ["Cloud", "Google"]
+        "url": "https://github.com/dataiku/dss-plugin-gke-clusters",
+        "tags": ["Cloud", "Google"],
+        "supportLevel": "TIER2_SUPPORT"
     }
 }

--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -26,16 +26,47 @@
             "defaultValue": "latest"
         },
         {
+            "name": "s-network",
+            "type": "SEPARATOR",
+            "label": "Networking",
+            "description": "<ul><li>For VPC-native clusters, leave IP ranges empty to let GKE automatically assign them.</li></ul>"
+        },
+        {
             "name": "network",
             "label": "Network",
+            "description": "Falls back to 'default' if empty",
             "type": "STRING",
             "mandatory" : false
         },
         {
             "name": "subNetwork",
-            "label": "Sub-network",
+            "label": "Subnetwork",
+            "description": "Falls back to 'default' if empty",
             "type": "STRING",
             "mandatory" : false
+        },
+        {
+            "name": "isVpcNative",
+            "label": "Make cluster VPC-native",
+            "description": "Allocate pod/service IPs directly from GCP network (RECOMMENDED)",
+            "type": "BOOLEAN",
+            "defaultValue": true
+        },
+        {
+            "name": "podIpRange",
+            "label": "Pod IP range",
+            "description": "Use CIDR block/mask notation, e.g. 10.0.0.0/24 or /24",
+            "type": "STRING",
+            "mandatory": false,
+            "visibilityCondition": "model.isVpcNative"
+        },
+        {
+            "name": "svcIpRange",
+            "label": "Service IP range",
+            "description": "Use CIDR block/mask notation, e.g. 10.0.0.0/24 or /24. MUST be different from pod IP range.",
+            "type": "STRING",
+            "mandatory": false,
+            "visibilityCondition": "model.isVpcNative"
         },
         {
             "name": "s-nodes",

--- a/python-lib/dku_kube/nvidia_utils.py
+++ b/python-lib/dku_kube/nvidia_utils.py
@@ -1,8 +1,6 @@
 import os
 import logging
 import subprocess
-
-from dku_utils.access import _has_not_blank_property
 from dku_utils.access import _is_none_or_blank
 
 DAEMONSET_MANIFEST_URL = "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml"
@@ -11,9 +9,11 @@ def create_installer_daemonset(kube_config_path=None):
     """
     Launch a pod on each node that will install the NVIDIA drivers.
     """
-
+    
     env = os.environ.copy()
     if not _is_none_or_blank(kube_config_path):
+        logging.info("Setting kube_config path from KUBECONFIG env variable...")
         env["KUBECONFIG"] = kube_config_path
-    logging.info("Starting NVIDIA driver installer daemonset with KUBECONFIG=%s" % kube_config_path)
+        logging.info("Found KUBECONFIG={}".format(env["KUBECONFIG"]))
+    logging.info("Creating NVIDIA driver daemonset (only GPU-tainted nodes will be affected)")
     subprocess.check_call(["kubectl", "apply", "-f", DAEMONSET_MANIFEST_URL], env=env)

--- a/python-lib/dku_utils/access.py
+++ b/python-lib/dku_utils/access.py
@@ -1,3 +1,4 @@
+from six import text_type
 from collections import Mapping, Iterable
 
 def _get_in_object_or_array(o, chunk, d):
@@ -16,7 +17,7 @@ def _safe_get_value(o, chunks, default_value=None):
         return _safe_get_value(_get_in_object_or_array(o, chunks[0], {}), chunks[1:], default_value)
 
 def _is_none_or_blank(x):
-    return x is None or (isinstance(x, str) and len(x.strip()) == 0) or (isinstance(x, unicode) and len(x.strip()) == 0)
+    return x is None or (isinstance(x, text_type) and len(x.strip()) == 0)
 
 def _has_not_blank_property(d, k):
     return k in d and not _is_none_or_blank(d[k])

--- a/python-runnables/add-node-pool/runnable.json
+++ b/python-runnables/add-node-pool/runnable.json
@@ -29,14 +29,14 @@
         },
         {
             "name": "nodePoolId",
-            "label": "Node pool",
+            "label": "Node pool ID",
             "description": "Id of node pool to create, if not default",
             "type": "STRING",
             "mandatory": false
         },
         {
             "name": "nodePoolConfig",
-            "label": "Node pool",
+            "label": "Node pool config",
             "type": "PRESET",
             "parameterSetId" : "node-pool-request",
             "mandatory" : true


### PR DESCRIPTION
* Cluster creation now spawns VPC-native clusters by default. Users can either let GKE do to IP range allocation automatically or define manually the pod & service ranges.

* Some other small fixes/improvements.