### PR TITLE
Remove 'Private key' field in connection settings

### DIFF
--- a/parameter-sets/connection-info/parameter-set.json
+++ b/parameter-sets/connection-info/parameter-set.json
@@ -9,16 +9,6 @@
     "defaultDefinableAtProjectLevel" : true,
     "defaultDefinableInline" : true,
 
-    "pluginParams": [
-        {
-            "name": "credentials",
-            "label": "Private key",
-            "description": "Must contain either the full path on the DSS server to a service account key file (.json or .p12), or the key as JSON. If empty, uses what was set by gcloud auth application-default login",
-            "type": "STRING",
-            "mandatory" : false
-        }
-    ],
-
     "params": [
         {
             "name": "projectId",


### PR DESCRIPTION
Removes the option of using a specific GCP Service Account key to authenticate against the GKE API at cluster creation time.

(There are currently some inconsistencies between the Service Account provided at cluster creation time and the K8S context where the user is defined with an auth-provider which directly fetches tokens from the `gcloud` command)
