### PR TITLE
Small improvements (default network & GCP service account settings)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=1.0.1
+PLUGIN_VERSION=1.0.2.dev
 PLUGIN_ID=gke-clusters
 
 plugin:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=1.1.0.dev
+PLUGIN_VERSION=1.1.0
 PLUGIN_ID=gke-clusters
 
 plugin:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=1.0.2.dev
+PLUGIN_VERSION=1.1.0.dev
 PLUGIN_ID=gke-clusters
 
 plugin:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ For more details, please see [the DSS reference documentation](https://doc.datai
 
 ## Release notes
 
+### v1.1.0
+
+- Clusters are now reusing the DSS host's VPC and subnetwork by default (can be changed by unticking the related parameter). Requires the `compute.zones.list` IAM permission.
+- Kubernetes labels can be defined for each node pool
+- Default service account running on nodes can be changed to a custom value or be inherited from the DSS host. Requires the `iam.serviceAccountUser` IAM permission
+
 ### v1.0.1
 
 - Clusters created from the plugin are now VPC-native by default.

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -123,7 +123,7 @@
             "description": "Leave blank to use the Compute Engine default service account",
             "type": "STRING",
             "mandatory": false,
-            "visibilityCondition": "model.serviceAccount == 'custom'"
+            "visibilityCondition": "model.serviceAccountType == 'custom'"
         },
         {
             "name": "diskType",

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -107,10 +107,32 @@
         },
         {
             "name": "serviceAccount",
-            "label": "Service account",
-            "description": "Run the cluster nodes as this service account. If left empty, the default account of the project is used.",
+            "label": "Service account type",
+            "description": "Run the cluster nodes as this GCP service account.",
+            "type": "SELECT",
+            "mandatory": true,
+            "selectChoices": [
+                {
+                    "value": "default",
+                    "label": "Default from GCP project"
+                },
+                {
+                    "value": "fromDSSHost",
+                    "label": "Same as DSS host"
+                },
+                {
+                    "value": "custom",
+                    "label": "Custom"
+                }
+            ],
+            "defaultValue": "default"
+        },
+        {
+            "name": "customNodepoolServiceAccount",
+            "label": "Service account name",
             "type": "STRING",
-            "mandatory" : false
+            "mandatory": false,
+            "visibilityCondition": "model.serviceAccount == 'custom'"
         },
         {
             "name": "diskType",

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -100,12 +100,6 @@
             "label" :"Advanced options"
         },
         {
-            "name": "nodepoolLabels",
-            "type": "MAP",
-            "label": "Labels",
-            "description": "Annotations specific to this node pool"
-        },
-        {
             "name": "serviceAccount",
             "label": "Service account type",
             "description": "Run the cluster nodes as this GCP service account.",
@@ -147,6 +141,12 @@
             "description": "Disk size for the nodes in gigabytes. Leave 0 for default (currently: 100GB).",
             "type": "INT",
             "mandatory" : false
+        },
+        {
+            "name": "nodepoolLabels",
+            "type": "MAP",
+            "label": "K8S labels",
+            "description": "Custom K8S metadata to attach to each node"
         }
     ]
 }

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -100,6 +100,12 @@
             "label" :"Advanced options"
         },
         {
+            "name": "nodepoolLabels",
+            "type": "MAP",
+            "label": "Labels",
+            "description": "Annotations specific to this node pool"
+        },
+        {
             "name": "serviceAccount",
             "label": "Service account",
             "description": "Run the cluster nodes as this service account. If left empty, the default account of the project is used.",

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -100,16 +100,12 @@
             "label" :"Advanced options"
         },
         {
-            "name": "serviceAccount",
+            "name": "serviceAccountType",
             "label": "Service account type",
             "description": "Run the cluster nodes as this GCP service account.",
             "type": "SELECT",
             "mandatory": true,
             "selectChoices": [
-                {
-                    "value": "default",
-                    "label": "Default from GCP project"
-                },
                 {
                     "value": "fromDSSHost",
                     "label": "Same as DSS host"
@@ -119,11 +115,12 @@
                     "label": "Custom"
                 }
             ],
-            "defaultValue": "default"
+            "defaultValue": "custom"
         },
         {
-            "name": "customNodepoolServiceAccount",
+            "name": "serviceAccount",
             "label": "Service account name",
+            "description": "Leave blank to use the Compute Engine default service account",
             "type": "STRING",
             "mandatory": false,
             "visibilityCondition": "model.serviceAccount == 'custom'"

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -141,7 +141,7 @@
         },
         {
             "name": "nodepoolLabels",
-            "type": "MAP",
+            "type": "KEY_VALUE_LIST",
             "label": "K8S labels",
             "description": "Custom K8S metadata to attach to each node"
         }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "gke-clusters",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "meta": {
         "label": "GKE clusters",
         "description": "Interact with Google Kubernetes Engine clusters",

--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -32,18 +32,27 @@
             "description": "<ul><li>For VPC-native clusters, leave IP ranges empty to let GKE automatically assign them.</li></ul>"
         },
         {
+            "name": "isInheritedFromDSSHost",
+            "label": "Inherit DSS host settings",
+            "type": "BOOLEAN",
+            "description": "Create cluster in same VPC/subnetwork as DSS host",
+            "default": true
+        },
+        {
             "name": "network",
             "label": "Network",
             "description": "Falls back to 'default' if empty",
             "type": "STRING",
-            "mandatory" : false
+            "mandatory" : false,
+            "visibilityCondition": "!model.isInheritedFromDSSHost"
         },
         {
             "name": "subNetwork",
             "label": "Subnetwork",
             "description": "Falls back to 'default' if empty",
             "type": "STRING",
-            "mandatory" : false
+            "mandatory" : false,
+            "visibilityCondition": "!model.isInheritedFromDSSHost"
         },
         {
             "name": "isVpcNative",

--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -97,7 +97,7 @@
         {
             "name": "clusterLabels",
             "label": "Labels",
-            "type": "MAP",
+            "type": "KEY_VALUE_LIST",
             "description": "Annotate all the cluster's related GCP resources"
         },
         {

--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -32,7 +32,7 @@
             "description": "<ul><li>For VPC-native clusters, leave IP ranges empty to let GKE automatically assign them.</li></ul>"
         },
         {
-            "name": "isInheritedFromDSSHost",
+            "name": "inheritFromDSSHost",
             "label": "Inherit DSS host settings",
             "type": "BOOLEAN",
             "description": "Create cluster in same VPC/subnetwork as DSS host",
@@ -44,7 +44,7 @@
             "description": "Falls back to 'default' if empty",
             "type": "STRING",
             "mandatory" : false,
-            "visibilityCondition": "!model.isInheritedFromDSSHost"
+            "visibilityCondition": "!model.inheritFromDSSHost"
         },
         {
             "name": "subNetwork",
@@ -52,7 +52,7 @@
             "description": "Falls back to 'default' if empty",
             "type": "STRING",
             "mandatory" : false,
-            "visibilityCondition": "!model.isInheritedFromDSSHost"
+            "visibilityCondition": "!model.inheritFromDSSHost"
         },
         {
             "name": "isVpcNative",

--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -95,6 +95,12 @@
             "label": "Advanced options"
         },
         {
+            "name": "clusterLabels",
+            "label": "Labels",
+            "type": "MAP",
+            "description": "Annotate all the cluster's related GCP resources"
+        },
+        {
             "name": "httpLoadBalancing",
             "label": "HTTP load balancing",
             "description": "Enable interaction with Google Cloud's load balancing abilities",

--- a/python-clusters/create-gke-cluster/cluster.py
+++ b/python-clusters/create-gke-cluster/cluster.py
@@ -45,8 +45,8 @@ class MyCluster(Cluster):
             node_pool_builder.with_machine_type(node_pool.get('machineType', None))
             node_pool_builder.with_disk_type(node_pool.get('diskType', None))
             node_pool_builder.with_disk_size_gb(node_pool.get('diskSizeGb', None))
-            node_pool_builder.with_service_account(node_pool.get('serviceAccount', None),
-                                                   node_pool.get('customNodepoolServiceAccount', None))
+            node_pool_builder.with_service_account(node_pool.get('serviceAccountType', None),
+                                                   node_pool.get('serviceAccount', None))
             node_pool_builder.with_auto_scaling(node_pool.get('numNodesAutoscaling', False), node_pool.get('minNumNodes', 2), node_pool.get('maxNumNodes', 5))
             node_pool_builder.with_gpu(node_pool.get('withGpu', False), node_pool.get('gpuType', None), node_pool.get('gpuCount', 1))
             node_pool_builder.with_nodepool_labels(node_pool.get('nodepoolLabels', {}))

--- a/python-clusters/create-gke-cluster/cluster.py
+++ b/python-clusters/create-gke-cluster/cluster.py
@@ -34,6 +34,7 @@ class MyCluster(Cluster):
         cluster_builder.with_vpc_native_settings(self.config.get("isVpcNative", None),
                                                  self.config.get("podIpRange", ""),
                                                  self.config.get("svcIpRange", ""))
+        cluster_builder.with_labels(self.config.get("clusterLabels", {}))
         cluster_builder.with_legacy_auth(self.config.get("legacyAuth", False))
         cluster_builder.with_http_load_balancing(self.config.get("httpLoadBalancing", False))
         for node_pool in self.config.get('nodePools', []):
@@ -47,6 +48,7 @@ class MyCluster(Cluster):
             node_pool_builder.with_service_account(node_pool.get('serviceAccount', None))
             node_pool_builder.with_auto_scaling(node_pool.get('numNodesAutoscaling', False), node_pool.get('minNumNodes', 2), node_pool.get('maxNumNodes', 5))
             node_pool_builder.with_gpu(node_pool.get('withGpu', False), node_pool.get('gpuType', None), node_pool.get('gpuCount', 1))
+            node_pool_builder.with_nodepool_labels(node_pool.get('nodepoolLabels', {}))
             node_pool_builder.build()
         cluster_builder.with_settings_valve(self.config.get("creationSettingsValve", None))
         

--- a/python-clusters/create-gke-cluster/cluster.py
+++ b/python-clusters/create-gke-cluster/cluster.py
@@ -28,7 +28,9 @@ class MyCluster(Cluster):
         cluster_builder.with_name(self.cluster_name)
         cluster_builder.with_version(self.config.get("clusterVersion", "latest"))
         cluster_builder.with_initial_node_count(self.config.get("numNodes", 3))
-        cluster_builder.with_network(self.config.get("network", "").strip(), self.config.get("subNetwork", "").strip())
+        cluster_builder.with_network(self.config.get("isInheritedFromDSSHost", True),
+                                     self.config.get("network", "").strip(),
+                                     self.config.get("subNetwork", "").strip())
         cluster_builder.with_vpc_native_settings(self.config.get("isVpcNative", None),
                                                  self.config.get("podIpRange", ""),
                                                  self.config.get("svcIpRange", ""))

--- a/python-clusters/create-gke-cluster/cluster.py
+++ b/python-clusters/create-gke-cluster/cluster.py
@@ -45,7 +45,8 @@ class MyCluster(Cluster):
             node_pool_builder.with_machine_type(node_pool.get('machineType', None))
             node_pool_builder.with_disk_type(node_pool.get('diskType', None))
             node_pool_builder.with_disk_size_gb(node_pool.get('diskSizeGb', None))
-            node_pool_builder.with_service_account(node_pool.get('serviceAccount', None))
+            node_pool_builder.with_service_account(node_pool.get('serviceAccount', None),
+                                                   node_pool.get('customNodepoolServiceAccount', None))
             node_pool_builder.with_auto_scaling(node_pool.get('numNodesAutoscaling', False), node_pool.get('minNumNodes', 2), node_pool.get('maxNumNodes', 5))
             node_pool_builder.with_gpu(node_pool.get('withGpu', False), node_pool.get('gpuType', None), node_pool.get('gpuCount', 1))
             node_pool_builder.with_nodepool_labels(node_pool.get('nodepoolLabels', {}))

--- a/python-clusters/create-gke-cluster/cluster.py
+++ b/python-clusters/create-gke-cluster/cluster.py
@@ -28,7 +28,7 @@ class MyCluster(Cluster):
         cluster_builder.with_name(self.cluster_name)
         cluster_builder.with_version(self.config.get("clusterVersion", "latest"))
         cluster_builder.with_initial_node_count(self.config.get("numNodes", 3))
-        cluster_builder.with_network(self.config.get("isInheritedFromDSSHost", True),
+        cluster_builder.with_network(self.config.get("inheritFromDSSHost", True),
                                      self.config.get("network", "").strip(),
                                      self.config.get("subNetwork", "").strip())
         cluster_builder.with_vpc_native_settings(self.config.get("isVpcNative", None),

--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -2,6 +2,7 @@ from googleapiclient import discovery
 from six import text_type
 from googleapiclient.errors import HttpError
 from dku_google.gcloud import get_sdk_root, get_access_token_and_expiry, get_project_region_and_zone
+from dku_google.gcloud import get_gce_network
 from dku_utils.access import _has_not_blank_property, _is_none_or_blank, _default_if_blank, _merge_objects
 
 import os, sys, json, re
@@ -155,9 +156,17 @@ class ClusterBuilder(object):
         self.version = version
         return self
     
-    def with_network(self, network, subnetwork):
-        self.network = _default_if_blank(network, None)
-        self.subnetwork = _default_if_blank(subnetwork, None)
+    def with_network(self, is_same_network_as_dss, network, subnetwork):
+        self.is_same_network_as_dss = is_same_network_as_dss
+        if self.is_same_network_as_dss:
+            logging.info("Cluster network/subnetwork is the SAME AS DSS HOST")
+            self.network, self.subnetwork = get_gce_network()
+        else:
+            logging.info("Cluster network/subnetwork is set EXPLICITLY")
+            self.network = _default_if_blank(network, None)
+            self.subnetwork = _default_if_blank(subnetwork, None)
+        logging.info("Cluster network is {}".format(self.network))
+        logging.info("Cluster subnetwork is {}".format(self.subnetwork))
         return self
     
     def get_node_pool_builder(self):

--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -75,6 +75,11 @@ class NodePoolBuilder(object):
         return self
     
     def with_service_account(self, service_account_type, custom_service_account_name):
+        """
+        Change default service account on cluster nodes.
+        Requires the iam.serviceAccountUser IAM permission.
+        """
+
         if service_account_type == "fromDSSHost":
             self.service_account = get_gce_service_account()
         elif service_account_type == "custom":

--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -83,9 +83,10 @@ class NodePoolBuilder(object):
         if service_account_type == "fromDSSHost":
             self.service_account = get_gce_service_account()
         elif service_account_type == "custom":
-            self.service_account = custom_service_account_name
+            if len(custom_service_account_name) == 0:
+                self.service_account = ""
         else:
-            self.service_account = ""
+            self.service_account = custom_service_account_name
         return self
     
     def with_settings_valve(self, settings_valve):

--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -81,12 +81,15 @@ class NodePoolBuilder(object):
         """
 
         if service_account_type == "fromDSSHost":
+            logging.info("Custer nodes will inherit the DSS host Service Account")
             self.service_account = get_instance_service_account()
-        elif service_account_type == "custom":
-            if len(custom_service_account_name) == 0:
+        if service_account_type == "custom":
+            if _is_none_or_blank(custom_service_account_name):
+                logging.info("Cluster nodes will have the default Compute Engine Service Account")
                 self.service_account = ""
-        else:
-            self.service_account = custom_service_account_name
+            else:
+                logging.info("Cluster nodes will have the custom Service Account: {}".format(custom_service_account_name))
+                self.service_account = custom_service_account_name
         return self
     
     def with_settings_valve(self, settings_valve):
@@ -257,8 +260,8 @@ class ClusterBuilder(object):
             ip_allocation_policy = {
                 "createSubnetwork": False,
                 "useIpAliases": True,
-                "servicesIpv4CidrBlock": cluster_pod_ip_range,
-                "clusterIpv4CidrBlock": cluster_svc_ip_range,
+                "servicesIpv4CidrBlock": cluster_svc_ip_range,
+                "clusterIpv4CidrBlock": cluster_pod_ip_range,
             }
             create_cluster_request_body["cluster"]["ipAllocationPolicy"] = ip_allocation_policy
 
@@ -383,8 +386,6 @@ class Cluster(object):
     def get_location_params(self):
         params = self.clusters.get_location_params().copy()
         params["clusterId"] = self.name
-        print("YOLO")
-        print(params)
         return params
     
     def get_node_pools_api(self):

--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -2,7 +2,7 @@ from googleapiclient import discovery
 from six import text_type
 from googleapiclient.errors import HttpError
 from dku_google.gcloud import get_sdk_root, get_access_token_and_expiry, get_project_region_and_zone
-from dku_google.gcloud import get_gce_network
+from dku_google.gcloud import get_gce_network, get_gce_service_account
 from dku_utils.access import _has_not_blank_property, _is_none_or_blank, _default_if_blank, _merge_objects
 
 import os, sys, json, re
@@ -74,8 +74,13 @@ class NodePoolBuilder(object):
         self.disk_size_gb = disk_size_gb
         return self
     
-    def with_service_account(self, service_account):
-        self.service_account = service_account
+    def with_service_account(self, service_account_type, custom_service_account_name):
+        if service_account_type == "fromDSSHost":
+            self.service_account = get_gce_service_account()
+        elif service_account_type == "custom":
+            self.service_account = custom_service_account_name
+        else:
+            self.service_account = ""
         return self
     
     def with_settings_valve(self, settings_valve):

--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -102,10 +102,11 @@ class NodePoolBuilder(object):
         self.gpu_count = gpu_count
         return self
 
-    def with_nodepool_labels(self, nodepool_labels = {}):
-        self.nodepool_labels.update(nodepool_labels)
-        if self.nodepool_labels:
-            logging.info("Adding labels {} to node pool {}".format(self.nodepool_labels, self.name))
+    def with_nodepool_labels(self, nodepool_labels=[]):
+        if nodepool_labels:
+            nodepool_labels_dict = {l["from"]: l["to"] for l in nodepool_labels}
+            logging.info("Adding labels {} to node pool {}".format(nodepool_labels_dict, self.name))
+            self.nodepool_labels.update(nodepool_labels_dict)
         return self
 
     def build(self):

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -59,10 +59,6 @@ def get_project_region_and_zone():
     region = _run_cmd(cmd+["compute/region"])
     zone = _run_cmd(cmd+["compute/zone"])
 
-    for prop in [project, region, zone]:
-        if len(prop) == 0:
-            raise ValueError("{} is UNSET, please configure gcloud accordingly".format(prop))
-
     return project, region, zone
 
 

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -61,7 +61,6 @@ def get_instance_info():
 
     metadata_flavor = {"Metadata-Flavor": "Google"}
     instance_info = {}
-    # Project name
     instance_info["project"] = requests.get("/".join([METADATA_SERVER_BASE_URL,
                                                       "project",
                                                       "project-id"]),
@@ -73,7 +72,7 @@ def get_instance_info():
     zone = zone_full.split("/")[-1] 
     instance_info["zone"] = zone
     instance_info["region"] = zone.split("-")[:-1]
-    instance_info["vm_name"] = requests.get("/"/join([METADATA_SERVER_BASE_URL,
+    instance_info["vm_name"] = requests.get("/".join([METADATA_SERVER_BASE_URL,
                                                       "instance",
                                                       "name"]),
                                             headers=metadata_flavor).text
@@ -88,7 +87,7 @@ def get_instance_network():
     instance_info = get_instance_info()
     cmd = ["gcloud", "compute", "instances", "describe"]
     cmd += [
-                    instance_info["name"],
+                    instance_info["vm_name"],
                     "--project",
                     instance_info["project"],
                     "--zone",
@@ -96,7 +95,7 @@ def get_instance_network():
                     "--format=json"
                 ]   
     instance_full_info = json.loads(_run_cmd(cmd))
-    network_interfaces = instance_info["networkInterfaces"]
+    network_interfaces = instance_full_info["networkInterfaces"]
     default_nic = network_interfaces[0]
     if len(network_interfaces) > 1:
         logging.info("WARNING! Multiple NICs detected, will use {}".format(default_nic))
@@ -112,7 +111,7 @@ def get_instance_service_account():
 
     logging.info("Retrieving gcloud auth info")
     cmd = ["gcloud", "auth", "list", "--format=json"]
-    instance_auth_info = json.loads(run_cmd(cmd))
+    instance_auth_info = json.loads(_run_cmd(cmd))
     for identity in instance_auth_info:
         if identity["status"] == "ACTIVE":
             instance_active_sa = identity["account"]

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -80,10 +80,7 @@ def _get_gce_instance_info():
     cmd_output_format = ["--format", "json"]
     cmd_base += cmd_output_format
 
-    try:
-        gce_instance_info_str = subprocess.check_output(cmd_base)
-    except subprocess.CalledProcessError as e:
-        print(e.output)
+    gce_instance_info_str = _run_cmd(cmd_base)
     gce_instance_info = json.loads(gce_instance_info_str)
 
     return gce_instance_info

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -59,11 +59,15 @@ def get_project_region_and_zone():
     region = _run_cmd(cmd+["compute/region"])
     zone = _run_cmd(cmd+["compute/zone"])
 
+    logging.info("The following config params were found for gcloud: PROJECT={}, REGION={}, ZONE={}".format(project, region, zone))
+
     return project, region, zone
 
 
 def _get_gce_instance_info():
     """
+    Run 'gcloud compute instances describe <the-host-vm>'
+    Requires the compute.zones.list IAM permission.
     """
     
     gce_instance_info = {}
@@ -79,7 +83,8 @@ def _get_gce_instance_info():
 
     cmd_output_format = ["--format", "json"]
     cmd_base += cmd_output_format
-
+    
+    logging.info("Running CMD {}".format(cmd_base))
     gce_instance_info_str = _run_cmd(cmd_base)
     gce_instance_info = json.loads(gce_instance_info_str)
 

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -116,3 +116,25 @@ def get_gce_labels():
 
     labels = _safe_get_value(_get_gce_instance_info(), "labels")
     return labels
+
+
+def get_gce_service_account():
+    """
+    Retrieve the active service account on the DSS host
+    """
+
+    logging.info("Retrieving gcloud auth info")
+    cmd_base = ["gcloud", "auth", "list"]
+    cmd_output_format = ["--format", "json"]
+    cmd_base += cmd_output_format
+
+    try:
+        gce_auth_info_str = subprocess.check_output(cmd_base)
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+    gce_auth_info = json.loads(gce_auth_info_str)
+    for identity in gce_auth_info:
+        if identity["status"] == "ACTIVE":
+            gce_active_sa = identity["account"]
+    logging.info("Active service account on DSS host is {}".format(gce_active_sa))
+    return gce_active_sa

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -54,8 +54,8 @@ class MyRunnable(Runnable):
         node_pool_builder.with_gpu(node_pool_config.get('withGpu', False),
                                    node_pool_config.get('gpuType', None),
                                    node_pool_config.get('gpuCount', 1))
-        node_pool_builder.with_service_account(node_pool_config.get('serviceAccount', None),
-                                               node_pool_config.get('customNodePoolServiceAccount', None))
+        node_pool_builder.with_service_account(node_pool_config.get('serviceAccountType', None),
+                                               node_pool_config.get('serviceAccount', None))
         node_pool_builder.with_nodepool_labels(node_pool_config.get('nodepoolLabels', {}))
         
         create_op = node_pool_builder.build()

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -54,7 +54,8 @@ class MyRunnable(Runnable):
         node_pool_builder.with_gpu(node_pool_config.get('withGpu', False),
                                    node_pool_config.get('gpuType', None),
                                    node_pool_config.get('gpuCount', 1))
-        node_pool_builder.with_service_account(node_pool_config.get('serviceAccount', None))
+        node_pool_builder.with_service_account(node_pool_config.get('serviceAccount', None),
+                                               node_pool_config.get('customNodePoolServiceAccount', None))
         
         create_op = node_pool_builder.build()
         logging.info("Waiting for cluster node pool creation")

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -56,6 +56,7 @@ class MyRunnable(Runnable):
                                    node_pool_config.get('gpuCount', 1))
         node_pool_builder.with_service_account(node_pool_config.get('serviceAccount', None),
                                                node_pool_config.get('customNodePoolServiceAccount', None))
+        node_pool_builder.with_nodepool_labels(node_pool_config.get('nodepoolLabels', {}))
         
         create_op = node_pool_builder.build()
         logging.info("Waiting for cluster node pool creation")


### PR DESCRIPTION
- By default, the cluster is now reusing the DSS host's VPC and subnetwork settings
- Labels can be defined at the cluster level (to annotate all the cluster nodes and resources) or at node pool level (to annotate only the node pool's VMs)
- By default, a node pool uses the default GCP service account (from the project's settings) but the user can choose either to reuse the DSS host's account or to specify a custom one. Should solve [ch45156](https://app.clubhouse.io/dataiku/story/45156/specify-which-serviceaccount-to-grant-to-gke-cluster-nodes-when-the-default-one-is-disabled) 

**Important** 
- Using the "Inherit DSS host settings" param requires the `compute.zones.list` permission
- Changing the default service account for the cluster nodes requires the `iam.serviceAccountUser` permission