### PR TITLE
update example ip pod range in cluster.json

### DIFF
--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -64,7 +64,7 @@
         {
             "name": "podIpRange",
             "label": "Pod IP range",
-            "description": "Use CIDR block/mask notation, e.g. 10.0.0.0/24 or /24",
+            "description": "Use CIDR block/mask notation, e.g. 10.0.0.0/21 or /21",
             "type": "STRING",
             "mandatory": false,
             "visibilityCondition": "model.isVpcNative"


### PR DESCRIPTION
update example pod ip range from /24 to /21. /24 range only allows one node cluster to be created. /21 allows for up to 8 node cluster.  see link https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips#cluster_sizing_secondary_range_pods