### PR TITLE
add ability to use named secondary ranges

### DIFF
--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -64,7 +64,7 @@
         {
             "name": "podIpRange",
             "label": "Pod IP range",
-            "description": "Use CIDR block/mask notation, e.g. 10.0.0.0/21 or /21",
+            "description": "Range name or CIDR block/mask notation, e.g. 10.0.0.0/21 or /21",
             "type": "STRING",
             "mandatory": false,
             "visibilityCondition": "model.isVpcNative"
@@ -72,7 +72,7 @@
         {
             "name": "svcIpRange",
             "label": "Service IP range",
-            "description": "Use CIDR block/mask notation, e.g. 10.0.0.0/24 or /24. MUST be different from pod IP range.",
+            "description": "Range name or CIDR block/mask notation, e.g. 10.0.0.0/24 or /24. MUST be different from pod IP range.",
             "type": "STRING",
             "mandatory": false,
             "visibilityCondition": "model.isVpcNative"

--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -260,10 +260,18 @@ class ClusterBuilder(object):
         if self.is_vpc_native:
             ip_allocation_policy = {
                 "createSubnetwork": False,
-                "useIpAliases": True,
-                "servicesIpv4CidrBlock": cluster_svc_ip_range,
-                "clusterIpv4CidrBlock": cluster_pod_ip_range,
+                "useIpAliases": True
             }
+            if re.match('[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+', cluster_svc_ip_range):
+                ip_allocation_policy["servicesIpv4CidrBlock"] = cluster_svc_ip_range
+            elif cluster_svc_ip_range is not None and len(cluster_svc_ip_range) > 0:
+                # assume it's an existing range name (shared VPC case)
+                ip_allocation_policy["servicesSecondaryRangeName"] = cluster_svc_ip_range
+            if re.match('[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+', cluster_pod_ip_range):
+                ip_allocation_policy["clusterIpv4CidrBlock"] = cluster_pod_ip_range
+            elif cluster_pod_ip_range is not None and len(cluster_pod_ip_range) > 0:
+                # assume it's an existing range name (shared VPC case)
+                ip_allocation_policy["clusterSecondaryRangeName"] = cluster_pod_ip_range
             create_cluster_request_body["cluster"]["ipAllocationPolicy"] = ip_allocation_policy
 
         if self.legacy_auth:


### PR DESCRIPTION
for clusters deployed on shared VPCs (where the network is in another project)