### PR TITLE
Bump to 1.1.4, add changelog, update Makefile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## Version 1.1.4 - Feature release
+- Add ability to use named secondary ranges
+- Add network tags on cluster nodes
+
+## Version 1.1.3 - Internal release
+- Fix unicode remnants in `Test network connectivity` macro
+- Fix subprocess incompatibilities with Python 3
+
+## Version 1.1.2
+- Fix string encoding issues in `Test network connectivity` macro
+
+## Version 1.1.1
+- Fix `Test network connectivity` macro when the hostname is already an IP.
+
+## Version 1.1.0
+
+- Clusters are now reusing the DSS host's VPC and subnetwork by default (can be changed by unticking the related parameter). Requires the `compute.zones.list` IAM permission.
+- Kubernetes labels can be defined for each node pool
+- Default service account running on nodes can be changed to a custom value or be inherited from the DSS host. Requires the `iam.serviceAccountUser` IAM permission
+
+## Version 1.0.1
+
+- Clusters created from the plugin are now VPC-native by default.

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,19 @@
-PLUGIN_VERSION=1.1.3
-PLUGIN_ID=gke-clusters
+plugin_id=`cat plugin.json | python -c "import sys, json; print(str(json.load(sys.stdin)['id']).replace('/',''))"`
+plugin_version=`cat plugin.json | python -c "import sys, json; print(str(json.load(sys.stdin)['version']).replace('/',''))"`
+archive_file_name="dss-plugin-${plugin_id}-${plugin_version}.zip"
+remote_url=`git config --get remote.origin.url`
+last_commit_id=`git rev-parse HEAD`
 
 plugin:
-	cat plugin.json|json_pp > /dev/null
+	@echo "[START] Archiving plugin to dist/ folder..."
+	@cat plugin.json | json_pp > /dev/null
+	@rm -rf dist
+	@mkdir dist
+	@echo "{\"remote_url\":\"${remote_url}\",\"last_commit_id\":\"${last_commit_id}\"}" > release_info.json
+	@git archive -v -9 --format zip -o dist/${archive_file_name} HEAD
+	@zip -u dist/${archive_file_name} release_info.json
+	@rm release_info.json
+	@echo "[SUCCESS] Archiving plugin to dist/ folder: Done!"
+
+dist-clean:
 	rm -rf dist
-	mkdir dist
-	zip --exclude "*.pyc" -r dist/dss-plugin-${PLUGIN_ID}-${PLUGIN_VERSION}.zip plugin.json code-env parameter-sets python-clusters python-lib python-runnables

--- a/README.md
+++ b/README.md
@@ -6,26 +6,7 @@ Requires DSS 6.0 or above.
 
 For more details, please see [the DSS reference documentation](https://doc.dataiku.com/dss/latest/containers/gke/index.html).
 
-## Release notes
-
-### v1.1.2
-- Fix string encoding issues in test network connectivity macro
-
-### v1.1.1
-- Fix `Test network connectivity` macro when the hostname is already an IP.
-
-### v1.1.0
-
-- Clusters are now reusing the DSS host's VPC and subnetwork by default (can be changed by unticking the related parameter). Requires the `compute.zones.list` IAM permission.
-- Kubernetes labels can be defined for each node pool
-- Default service account running on nodes can be changed to a custom value or be inherited from the DSS host. Requires the `iam.serviceAccountUser` IAM permission
-
-### v1.0.1
-
-- Clusters created from the plugin are now VPC-native by default.
-
-
 ## License
-Copyright (C) 2019-2021 Dataiku
+Copyright (C) 2019-2022  Dataiku
 
 Licensed under the Apache License, version 2.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "gke-clusters",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "meta": {
         "label": "GKE clusters",
         "description": "Interact with Google Kubernetes Engine clusters",


### PR DESCRIPTION
Same story as the other cluster plugins:
* Update to 1.1.4 (mark 1.1.3 as an internal release since it was never published on the store)
* Create a dedicated changelog and update the Makefile to match the plugin template: https://github.com/dataiku/dss-plugin-template