### PR TITLE
Task/regional clusters

### DIFF
--- a/parameter-sets/connection-info/parameter-set.json
+++ b/parameter-sets/connection-info/parameter-set.json
@@ -23,6 +23,13 @@
             "type": "STRING",
             "description": "If empty, uses what was set by gcloud auth application-default login",
             "mandatory" : false
+        },
+        {
+            "name": "region",
+            "label": "GCP Region",
+            "type": "STRING",
+            "description": "If empty, inferred from zone",
+            "mandatory" : false
         }
     ]
 }

--- a/python-clusters/attach-gke-cluster/cluster.json
+++ b/python-clusters/attach-gke-cluster/cluster.json
@@ -22,6 +22,13 @@
             "mandatory" : true
         },
         {
+            "name": "isRegional",
+            "label": "Regional",
+            "description": "Whether the cluster is regional (if not, it's zonal)",
+            "type": "BOOLEAN",
+            "defaultValue" : false
+        },
+        {
             "name": "userName",
             "label": "User name",
             "description": "If not the same as the gcloud user",

--- a/python-clusters/attach-gke-cluster/cluster.py
+++ b/python-clusters/attach-gke-cluster/cluster.py
@@ -22,7 +22,8 @@ class MyCluster(Cluster):
         # this will fail if the cluster doesn't exist, but the API message is enough
         clusters = get_cluster_from_connection_info(self.config['connectionInfo'], self.plugin_config['connectionInfo'])
                 
-        cluster = clusters.get_cluster(self.config.get('clusterId', self.cluster_name))
+        is_regional = self.config.get('isRegional', False)
+        cluster = clusters.get_cluster(self.config.get('clusterId', self.cluster_name), 'regional' if is_regional else 'zonal')
         cluster_info = cluster.get_info()
 
         # build the config file for kubectl

--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -25,6 +25,21 @@
             "defaultValue": "latest"
         },
         {
+            "name": "isRegional",
+            "label": "Regional",
+            "description": "Whether the cluster is regional (if not, it's zonal)",
+            "type": "BOOLEAN",
+            "defaultValue" : false
+        },
+        {
+            "name": "locations",
+            "label": "Locations",
+            "description": "Zones in which nodepools are created (if empty, all zones of the region)",
+            "type": "STRINGS",
+            "mandatory": false,
+            "visibilityCondition": "model.isRegional"
+        },
+        {
             "name": "s-network",
             "type": "SEPARATOR",
             "label": "Networking",

--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -22,14 +22,28 @@
             "name": "clusterVersion",
             "label": "Kubernetes version",
             "type": "STRING",
-            "defaultValue": "latest"
+            "defaultValue": "latest",
+            "visibilityCondition": "!model.isAutopilot"
+        },
+        {
+            "name": "releaseChannel",
+            "label": "Release Channel",
+            "type": "SELECT",
+            "defaultValue": "STABLE",
+            "selectChoices": [
+                {"label":"Stable", "value":"STABLE"},
+                {"label":"Regular", "value":"REGULAR"},
+                {"label":"Rapid", "value":"RAPID"}
+            ],
+            "visibilityCondition": "model.isAutopilot"
         },
         {
             "name": "isRegional",
             "label": "Regional",
             "description": "Whether the cluster is regional (if not, it's zonal)",
             "type": "BOOLEAN",
-            "defaultValue" : false
+            "defaultValue" : false,
+            "visibilityCondition": "!model.isAutopilot"
         },
         {
             "name": "locations",
@@ -37,7 +51,7 @@
             "description": "Zones in which nodepools are created (if empty, all zones of the region)",
             "type": "STRINGS",
             "mandatory": false,
-            "visibilityCondition": "model.isRegional"
+            "visibilityCondition": "!model.isAutopilot && model.isRegional"
         },
         {
             "name": "s-network",
@@ -73,7 +87,8 @@
             "label": "Make cluster VPC-native",
             "description": "Allocate pod/service IPs directly from GCP network (RECOMMENDED)",
             "type": "BOOLEAN",
-            "defaultValue": true
+            "defaultValue": true,
+            "visibilityCondition": "!model.isAutopilot"
         },
         {
             "name": "podIpRange",
@@ -94,7 +109,8 @@
         {
             "name": "s-nodes",
             "type":"SEPARATOR",
-            "label": "Cluster nodes"
+            "label": "Cluster nodes",
+            "visibilityCondition": "!model.isAutopilot"
         },
         {
             "name": "nodePools",
@@ -102,11 +118,19 @@
             "description": "Node pools to create in the cluster",
             "type": "PRESETS",
             "parameterSetId": "node-pool-request",
-            "mandatory": true
+            "mandatory": true,
+            "visibilityCondition": "!model.isAutopilot"
         },
          {
             "type":"SEPARATOR",
             "label": "Advanced options"
+        },
+        {
+            "name": "isAutopilot",
+            "label": "Autopilot",
+            "description": "Create a cluster with node pools managed by GKE",
+            "type": "BOOLEAN",
+            "defaultValue" : false
         },
         {
             "name": "clusterLabels",
@@ -119,14 +143,16 @@
             "label": "HTTP load balancing",
             "description": "Enable interaction with Google Cloud's load balancing abilities",
             "type": "BOOLEAN",
-            "defaultValue": true
+            "defaultValue": true,
+            "visibilityCondition": "!model.isAutopilot"
         },
         {
             "name": "legacyAuth",
             "label": "Legacy auth",
             "description": "Use client certificate instead of GCP auth provider",
             "type": "BOOLEAN",
-            "defaultValue": false
+            "defaultValue": false,
+            "visibilityCondition": "!model.isAutopilot"
         },
         {
             "name": "creationSettingsValve",

--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -604,7 +604,7 @@ class Clusters(object):
         else:
             self.zone = zone
         if _is_none_or_blank(region):
-            default_region = self.zone.split("-")[:-1]
+            default_region = '-'.join(self.zone.split("-")[:-1])
             logging.info("No region specified, using {} as default".format(default_region))
             self.region = default_region
         else:

--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -393,10 +393,11 @@ class NodePool(object):
             raise Exception("Failed to create node pool : %s" % str(e))
 
 class Cluster(object):
-    def __init__(self, name, clusters, definition_level='zonal'):
+    def __init__(self, name, definition_level, clusters):
         self.name = name
         self.clusters = clusters
         self.definition_level = definition_level
+        logging.info("Cluster object named %s of level %s" % (name, definition_level))
         
     def get_location(self):
         if self.definition_level == 'zonal':
@@ -434,8 +435,8 @@ class Cluster(object):
         return self.clusters.get_instance_groups_api()
         
     def get_info(self):
-        location_params = self.get_location_params()
-        request = self.get_clusters_api().get(**location_params)
+        location = self.get_location()
+        request = self.get_clusters_api().get(name=location)
         response = request.execute()
         return response
 
@@ -569,10 +570,10 @@ class Clusters(object):
         return {"projectId":self.project_id, "region":self.region}
     
     def get_regional_operations_api(self):
-        return self.service.projects().regions().operations()
+        return self.service.projects().locations().operations()
     
     def get_regional_clusters_api(self):
-        return self.service.projects().regions().clusters()
+        return self.service.projects().locations().clusters()
     
     def get_instance_groups_api(self):
         return self.compute.instanceGroups()
@@ -580,5 +581,5 @@ class Clusters(object):
     def new_cluster_builder(self):
         return ClusterBuilder(self)
     
-    def get_cluster(self, name):
-        return Cluster(name, self)
+    def get_cluster(self, name, definition_level='zonal'):
+        return Cluster(name, definition_level, self)

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -71,7 +71,7 @@ def get_instance_info():
                         headers=metadata_flavor).text
     zone = zone_full.split("/")[-1] 
     instance_info["zone"] = zone
-    instance_info["region"] = zone.split("-")[:-1]
+    instance_info["region"] = '-'.join(zone.split("-")[:-1])
     instance_info["vm_name"] = requests.get("/".join([METADATA_SERVER_BASE_URL,
                                                       "instance",
                                                       "name"]),

--- a/python-lib/dku_google/operations.py
+++ b/python-lib/dku_google/operations.py
@@ -7,9 +7,12 @@ import logging
 class Operation(object):
     def __init__(self, operation, operations, location_data):
         self.operation = operation
-        self.operations = operations
-        self.location_data = location_data
         self.operation_id = operation["name"]
+        self.operations = operations
+        if 'region' in location_data:
+            # the regional api uses the 'name' arg, not the old projectId/zone/... ones
+            location_data = {"name": 'projects/%s/locations/%s/operations/%s' % (location_data['projectId'], location_data['region'], self.operation_id)}
+        self.location_data = location_data
         
     def _refresh(self):
         self.operation = self.operations.get(operationId=self.operation_id, **self.location_data).execute()

--- a/python-lib/dku_utils/cluster.py
+++ b/python-lib/dku_utils/cluster.py
@@ -23,7 +23,7 @@ def get_cluster_from_connection_info(config_connection_info, plugin_config_conne
     credentials = None
     if _has_not_blank_property(plugin_config_connection_info, 'credentials'):
         credentials = get_credentials_from_json_or_file(plugin_config_connection_info['credentials'])
-    return Clusters(config_connection_info.get("projectId", None), config_connection_info.get("zone", None), credentials)
+    return Clusters(config_connection_info.get("projectId", None), config_connection_info.get("zone", None), config_connection_info.get("region", None), credentials)
 
 def get_cluster_from_dss_cluster(dss_cluster_id):
     # get the public API client

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -17,20 +17,9 @@ class MyRunnable(Runnable):
         return None
 
     def run(self, progress_callback):
-        cluster_data, clusters, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
+        cluster_data, cluster, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
 
         kube_config_path = dss_cluster_settings.get_raw()['containerSettings']['executionConfigsGenericOverrides']['kubeConfigPath']
-
-        # retrieve the actual name in the cluster's data
-        if cluster_data is None:
-            raise Exception("No cluster data (not started?)")
-        cluster_def = cluster_data.get("cluster", None)
-        if cluster_def is None:
-            raise Exception("No cluster definition (starting failed?)")
-        cluster_name = cluster_def["name"]
-
-        # get the object for the cluster, GKE side
-        cluster = clusters.get_cluster(cluster_name)
 
         node_pool_id = self.config.get('nodePoolId', None)
         node_pools = cluster.get_node_pools()

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -18,6 +18,9 @@ class MyRunnable(Runnable):
 
     def run(self, progress_callback):
         cluster_data, cluster, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
+        
+        if cluster_data.get("cluster", {}).get("autopilot", {}).get("enabled", False):
+            raise Exception("Nodepools aren't accessible on autopilot clusters")
 
         kube_config_path = dss_cluster_settings.get_raw()['containerSettings']['executionConfigsGenericOverrides']['kubeConfigPath']
 

--- a/python-runnables/inspect-node-pools/runnable.py
+++ b/python-runnables/inspect-node-pools/runnable.py
@@ -14,18 +14,7 @@ class MyRunnable(Runnable):
         return None
 
     def run(self, progress_callback):
-        cluster_data, clusters, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
-        # retrieve the actual name in the cluster's data
-        if cluster_data is None:
-            raise Exception("No cluster data (not started?)")
-        cluster_def = cluster_data.get("cluster", None)
-        if cluster_def is None:
-            raise Exception("No cluster definition (starting failed?)")
-        cluster_name = cluster_def["name"]
-        
-        # get the object for the cluster, GKE side
-        print(clusters.zone)
-        cluster = clusters.get_cluster(cluster_name)
+        cluster_data, cluster, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
         
         node_pool_id = self.config.get('nodePoolId', None)
         if node_pool_id is None or len(node_pool_id) == 0:

--- a/python-runnables/inspect-node-pools/runnable.py
+++ b/python-runnables/inspect-node-pools/runnable.py
@@ -16,6 +16,9 @@ class MyRunnable(Runnable):
     def run(self, progress_callback):
         cluster_data, cluster, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
         
+        if cluster_data.get("cluster", {}).get("autopilot", {}).get("enabled", False):
+            raise Exception("Nodepools aren't accessible on autopilot clusters")
+        
         node_pool_id = self.config.get('nodePoolId', None)
         if node_pool_id is None or len(node_pool_id) == 0:
             node_pools = cluster.get_node_pools() # CRASHES HERE

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -16,6 +16,9 @@ class MyRunnable(Runnable):
     def run(self, progress_callback):
         cluster_data, cluster, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
         
+        if cluster_data.get("cluster", {}).get("autopilot", {}).get("enabled", False):
+            raise Exception("Nodepools aren't accessible on autopilot clusters")
+        
         node_pool_id = self.config.get('nodePoolId', None)
         node_pools = cluster.get_node_pools()
         if node_pool_id is None or len(node_pool_id) == 0:

--- a/python-runnables/resize-node-pool/runnable.py
+++ b/python-runnables/resize-node-pool/runnable.py
@@ -14,18 +14,7 @@ class MyRunnable(Runnable):
         return None
 
     def run(self, progress_callback):
-        cluster_data, clusters, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
-
-        # retrieve the actual name in the cluster's data
-        if cluster_data is None:
-            raise Exception("No cluster data (not started?)")
-        cluster_def = cluster_data.get("cluster", None)
-        if cluster_def is None:
-            raise Exception("No cluster definition (starting failed?)")
-        cluster_name = cluster_def["name"]
-        
-        # get the object for the cluster, GKE side
-        cluster = clusters.get_cluster(cluster_name)
+        cluster_data, cluster, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
         
         node_pool_id = self.config.get('nodePoolId', None)
         node_pools = cluster.get_node_pools()


### PR DESCRIPTION
[sc-77883]

most of the work is adding support for regional clusters, in the create/attach cluster, and in the actions for inspecting and modifying nodepools.

The checkbox for creating an autopilot cluster is purposely hidden at the bottom in the advanced section of the settings, so that users are not too tempted to use it