### PR TITLE
[sc-111696] remove legacy ABAC auth

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Next version
 - Fix the cluster configuration's merging mechanism for string parameters
-- Decommission the legacy authorization (ABAC)
+- Remove support for legacy authorization (ABAC)
 
 ##  Version 1.1.5 - Feature and bugfix release
 - Fix action "Add node pool"

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Next version
 - Fix the cluster configuration's merging mechanism for string parameters
+- Decommission the legacy authorization (ABAC)
 
 ##  Version 1.1.5 - Feature and bugfix release
 - Fix action "Add node pool"

--- a/python-clusters/attach-gke-cluster/cluster.json
+++ b/python-clusters/attach-gke-cluster/cluster.json
@@ -34,13 +34,6 @@
             "description": "If not the same as the gcloud user",
             "type": "STRING",
             "mandatory" : false
-        },
-        {
-            "name": "legacyAuth",
-            "label": "Legacy auth",
-            "description": "Use client certificate instead of GCP auth provider",
-            "type": "BOOLEAN",
-            "defaultValue" : false
         }
     ]
 }

--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -147,14 +147,6 @@
             "visibilityCondition": "!model.isAutopilot"
         },
         {
-            "name": "legacyAuth",
-            "label": "Legacy auth",
-            "description": "Use client certificate instead of GCP auth provider",
-            "type": "BOOLEAN",
-            "defaultValue": false,
-            "visibilityCondition": "!model.isAutopilot"
-        },
-        {
             "name": "creationSettingsValve",
             "label": "Custom creation settings",
             "description": "Additional settings for the cluster creation call, as JSON",

--- a/python-clusters/create-gke-cluster/cluster.py
+++ b/python-clusters/create-gke-cluster/cluster.py
@@ -44,7 +44,6 @@ class MyCluster(Cluster):
                                                  self.config.get("svcIpRange", ""))
         cluster_builder.with_labels(self.config.get("clusterLabels", {}))
         if not is_autopilot:
-            cluster_builder.with_legacy_auth(self.config.get("legacyAuth", False))
             cluster_builder.with_http_load_balancing(self.config.get("httpLoadBalancing", False))
             if is_regional:
                 cluster_builder.with_regional(True, self.config.get("locations", []))


### PR DESCRIPTION
Remove the legacy ABAC auth. The users who want to keep using it will be able to use a previous version of the plugin.

To be merged before [Kubernetes 1.26 support PR](https://github.com/dataiku/dss-plugin-gke-clusters/pull/20).