### PR TITLE
Allow py36 to py311

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.3.0
+- Add more supported Python versions. This plugin can now use 2.7 (deprecated), 3.6, 3.7, 3.8, 3.9, 3.10 (experimental), 3.11 (experimental)
+
 ## Version 1.2.0
 - Fix the cluster configuration's merging mechanism for string parameters
 - Remove support for legacy authorization (ABAC)

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,6 +1,7 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON36", "PYTHON37"],
+  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36", "PYTHON37", "PYTHON38", "PYTHON39", "PYTHON310", "PYTHON311"],
   "forceConda": false,
   "installCorePackages": true,
+  "corePackagesSet": "AUTO",
   "installJupyterSupport": false
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "gke-clusters",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "meta": {
         "label": "GKE clusters",
         "description": "Interact with Google Kubernetes Engine clusters",

--- a/python-lib/dku_utils/access.py
+++ b/python-lib/dku_utils/access.py
@@ -1,5 +1,8 @@
 from six import text_type
-from collections import Mapping, Iterable
+try:
+    from collections.abc import Mapping, Iterable # py3
+except ImportError:
+    from collections import Mapping, Iterable # py2
 import sys
 
 if sys.version_info > (3,):


### PR DESCRIPTION
I tested each python by:
- Launching 2 clusters, one with default settings, one with as much settings filled as possible (and a GPU on top)
- test connectivity
- look at monitoring
- checking gpu resence in the node overview
- running a recipe + notebook (only on the cluster with "default settings")

2.7, 3.6, 3.9 and 3.11 had more tests:
- all the macros
- running a recipe + notebook (on the other cluster too)
- attaching

Last, I did an autopilot cluster only on 3.11. Realised too late the "network connectivity" test is broken anyway for autopilot (_I think_ scaling up is too slow), so only can test by running a recipe + notebook