### PR TITLE
Improve error message when missing gcloud auth

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next version
+- Improve error message when gcloud has not been properly authorized
+
 ## Version 1.3.0
 - Add more supported Python versions. This plugin can now use 2.7 (deprecated), 3.6, 3.7, 3.8, 3.9, 3.10 (experimental), 3.11 (experimental)
 - Fix issue when creating a cluster in a different region/zone

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -42,16 +42,20 @@ def get_account():
 
 def _run_cmd(cmd=None, **kwargs):
     """
-    Run command via subprocess. Clean retrieval of error message if fails. Trims any trailing space.
+    Run command via subprocess. Clean retrieval and throw of error message if fails. Trims any trailing space.
     """
 
     logging.info("Running CMD {}".format(cmd))
-    try:
-        out = subprocess.check_output(cmd, **kwargs).rstrip()
-        return out
-    except subprocess.CalledProcessError as e:
-        logging.error(e.output)
-    return
+    p = subprocess.Popen(cmd,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         universal_newlines=True,
+                         **kwargs)
+    out, err = p.communicate()
+    rv = p.wait()
+    if rv != 0:
+        raise Exception(err)
+    return out.rstrip()
 
 
 def get_instance_info():


### PR DESCRIPTION
There seems to be no way to cleanly retrieve `stderr` (separated from `stdout`) with `check_output` that works in python 2.7, so I had to switch to the standard `subprocess.Popen`. Tested in both 2.7 and 3.11 (in cases with and without an error).

Before, we used to return `None` when the command failed with an error. I don't see why we wouldn't want to raise an Exception instead, in each of the cases that use the `_run_cmd` method.

[sc-98464]