### PR TITLE
Improve IP range regex and field descriptions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next version
+- Fix CIDR block detection and improve descriptions of pod and service IP range fields
+
 ## Version 1.3.0
 - Add more supported Python versions. This plugin can now use 2.7 (deprecated), 3.6, 3.7, 3.8, 3.9, 3.10 (experimental), 3.11 (experimental)
 - Fix issue when creating a cluster in a different region/zone

--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -93,7 +93,7 @@
         {
             "name": "podIpRange",
             "label": "Pod IP range",
-            "description": "Range name or CIDR block/mask notation, e.g. 10.0.0.0/21 or /21. If using a named range, ensure it is larger than /21.",
+            "description": "[Optional] Range name or CIDR block/mask notation, e.g. 10.1.0.0/14 or /14. MUST not overlap with the subnet IP range. If using a named range, ensure it is at least as large as /21.",
             "type": "STRING",
             "mandatory": false,
             "visibilityCondition": "model.isVpcNative"
@@ -101,7 +101,7 @@
         {
             "name": "svcIpRange",
             "label": "Service IP range",
-            "description": "Range name or CIDR block/mask notation, e.g. 10.0.0.0/24 or /24. MUST be different from pod IP range.",
+            "description": "[Optional] Range name or CIDR block/mask notation, e.g. 10.2.0.0/20 or /20. MUST not overlap with the subnet IP range nor the pod IP range.",
             "type": "STRING",
             "mandatory": false,
             "visibilityCondition": "model.isVpcNative"

--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -288,12 +288,14 @@ class ClusterBuilder(object):
                 "createSubnetwork": False,
                 "useIpAliases": True
             }
-            if re.match('[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+', cluster_svc_ip_range):
+            # Should match both a.b.c.d/e and /e
+            range_regex = '^([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)?/[0-9]+$'
+            if re.match(range_regex, cluster_svc_ip_range):
                 ip_allocation_policy["servicesIpv4CidrBlock"] = cluster_svc_ip_range
             elif cluster_svc_ip_range is not None and len(cluster_svc_ip_range) > 0:
                 # assume it's an existing range name (shared VPC case)
                 ip_allocation_policy["servicesSecondaryRangeName"] = cluster_svc_ip_range
-            if re.match('[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+', cluster_pod_ip_range):
+            if re.match(range_regex, cluster_pod_ip_range):
                 ip_allocation_policy["clusterIpv4CidrBlock"] = cluster_pod_ip_range
             elif cluster_pod_ip_range is not None and len(cluster_pod_ip_range) > 0:
                 # assume it's an existing range name (shared VPC case)


### PR DESCRIPTION
* Regarding the error when entering a block like `/16` or `/20`, it was an issue with the regex
* I updated the descriptions to suggest ranges that actually work and mentioned that the ranges should not overlap
* Regarding parsing and rejecting "bad" ranges ourselves, I don't think there's much value added in doing that since the errors returned are understandable.
* To test "named ranges", go to your VPC network -> Click on the subnet -> "Edit" -> "Add IP range" and add the secondary ranges you want to use for pods and services. Then use the names of those new ranges in the plugin fields.
* I tested putting in invalid ranges (see https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips#cluster_sizing_secondary_range_pods), like `/8` and `/22`, or having the pod and service ranges overlap. The errors seemed fine to me.

[sc-92162]