### PR TITLE
UI improvements in nodepool definitions

### DIFF
--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -165,7 +165,6 @@
         {
             "name": "nodepoolTaints",
             "label": "Nodepool taints",
-            "description": "<div class=\"alert alert-warning\"><i class=\"icon-dku-warning\"/><span>WARNING: MUST CREATE AT LEAST ONE NODE POOL WITHOUT TAINTS. <a href=\"https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/\">See documentation</a></span></div>",
             "mandatory": false,
             "type": "OBJECT_LIST",
             "subParams": [
@@ -198,6 +197,10 @@
                     "defaultValue": "NO_SCHEDULE"
                 }
             ]
+        },
+        {
+            "type": "SEPARATOR",
+            "description": "<div class=\"alert alert-warning\"><i class=\"icon-dku-warning\"/><span>WARNING: MUST CREATE AT LEAST ONE NODE POOL WITHOUT TAINTS. <a href=\"https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/\">See documentation</a></span></div>"
         },
         {
             "name": "nodepoolGCPLabels",

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -165,7 +165,7 @@
         {
             "name": "nodepoolTaints",
             "label": "Nodepool taints",
-            "description": "WARNING: MUST CREATE AT LEAST ONE NODE POOL WITHOUT TAINTS. https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+            "description": "<div class=\"alert alert-warning\"><i class=\"icon-dku-warning\"/><span>WARNING: MUST CREATE AT LEAST ONE NODE POOL WITHOUT TAINTS. <a href=\"https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/\">See documentation</a></span></div>",
             "mandatory": false,
             "type": "OBJECT_LIST",
             "subParams": [

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -200,7 +200,8 @@
         },
         {
             "type": "SEPARATOR",
-            "description": "<div class=\"alert alert-warning\"><i class=\"icon-dku-warning\"/><span>WARNING: MUST CREATE AT LEAST ONE NODE POOL WITHOUT TAINTS. <a href=\"https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/\">See documentation</a></span></div>"
+            "description": "<div class=\"alert alert-warning\"><i class=\"icon-dku-warning\"/><span>WARNING: MUST CREATE AT LEAST ONE NODE POOL WITHOUT TAINTS. <a href=\"https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/\">See documentation</a></span></div>",
+            "visibilityCondition": "model.nodepoolTaints && (model.nodepoolTaints.length > 0)"
         },
         {
             "name": "nodepoolGCPLabels",

--- a/parameter-sets/node-pool-request/parameter-set.json
+++ b/parameter-sets/node-pool-request/parameter-set.json
@@ -10,7 +10,12 @@
     "pluginParams": [
     ],
     "params": [
-       {
+        {
+            "type": "SEPARATOR",
+            "label": "Node pool definition",
+            "description": "<hr>"
+        },
+        {
             "name": "machineType",
             "label": "Machine type",
             "description": "GCE machine type for the nodes. See GCP documentation for available machine types.",


### PR DESCRIPTION
There was feedback that the nodepool definitions were not super clear in terms of where they started and ended. It was making the list of nodepools difficult to read so we add a separator with a line to delimit the definitions.

It was also brought up that it's not clear enough that there should always be a nodepool without taints. The first step is to make the warning that already existed more visible by using the separator (they can contain HTML).

The result looks something like this:
<img width="2534" alt="image" src="https://github.com/user-attachments/assets/8c063064-8f59-445c-a98f-69cf289c39f6">

The warning was put into a yellow warning box, we could keep only the icon if it's too distracting and the nodepool definition separator could also be made larger if necessary.

Also linking [sc-203970]

Shortcut bot is not linking cards:
https://app.shortcut.com/dataiku/story/203970/plugin-gke-add-check-that-there-is-at-least-one-nodepool-without-taint-before-starting-cluster
https://app.shortcut.com/dataiku/story/204977/plugin-gke-add-separator-in-nodepool-parameter-set
