### PR TITLE
Surfaced DNS endpoint attach option

### DIFF
--- a/python-clusters/attach-gke-cluster/cluster.json
+++ b/python-clusters/attach-gke-cluster/cluster.json
@@ -31,7 +31,7 @@
         {
             "name": "isDnsEndpoint",
             "label": "Use DNS Endpoint",
-            "description": "Force DNS Endpoint connection the ControlPlane. DNS Endpoint must have been configured already. If not selected, will use IP address. DNS Endpoint info here https://cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation#dns-based-endpoint",
+            "description": "Force DNS Endpoint connection to the ControlPlane. DNS Endpoint must have been configured already. If not selected, will use IP address. DNS Endpoint info here https://cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation#dns-based-endpoint",
             "type": "BOOLEAN",
             "defaultValue" : false
         },

--- a/python-clusters/attach-gke-cluster/cluster.json
+++ b/python-clusters/attach-gke-cluster/cluster.json
@@ -31,7 +31,7 @@
         {
             "name": "isDnsEndpoint",
             "label": "Use DNS Endpoint",
-            "description": "Whether to use the DNS Endpoint to connect to the cluster. If not selected, will use IP",
+            "description": "Force DNS Endpoint connection the ControlPlane. DNS Endpoint must have been configured already. If not selected, will use IP address. DNS Endpoint info here https://cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation#dns-based-endpoint",
             "type": "BOOLEAN",
             "defaultValue" : false
         },

--- a/python-clusters/attach-gke-cluster/cluster.json
+++ b/python-clusters/attach-gke-cluster/cluster.json
@@ -29,6 +29,13 @@
             "defaultValue" : false
         },
         {
+            "name": "isDnsEndpoint",
+            "label": "Use DNS Endpoint",
+            "description": "Whether to use the DNS Endpoint to connect to the cluster. If not selected, will use IP",
+            "type": "BOOLEAN",
+            "defaultValue" : false
+        },
+        {
             "name": "userName",
             "label": "User name",
             "description": "If not the same as the gcloud user",

--- a/python-clusters/attach-gke-cluster/cluster.json
+++ b/python-clusters/attach-gke-cluster/cluster.json
@@ -31,7 +31,7 @@
         {
             "name": "isDnsEndpoint",
             "label": "Use DNS Endpoint",
-            "description": "Force DNS Endpoint connection to the ControlPlane. DNS Endpoint must have been configured already. If not selected, will use IP address. DNS Endpoint info here https://cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation#dns-based-endpoint",
+            "description": "Force DNS Endpoint connection to the ControlPlane. DNS Endpoint must have been configured already. If not selected, will use IP address. DNS Endpoint info here: https://cloud.google.com/kubernetes-engine/docs/how-to/latest/network-isolation#dns-based-endpoint",
             "type": "BOOLEAN",
             "defaultValue" : false
         },

--- a/python-clusters/attach-gke-cluster/cluster.py
+++ b/python-clusters/attach-gke-cluster/cluster.py
@@ -30,7 +30,8 @@ class MyCluster(Cluster):
         # delegate the creation of the kube config file to gcloud to use the client go auth plugin
         kube_config_path = os.path.join(os.getcwd(), 'kube_config')
         region_or_zone = clusters.region if is_regional else clusters.zone
-        create_kube_config_file(clusters.project_id, cluster.name, is_regional, region_or_zone, kube_config_path)
+        is_dns_endpont = self.config.get('isDnsEndpoint', False)
+        create_kube_config_file(clusters.project_id, cluster.name, is_regional, region_or_zone, kube_config_pa, is_dns_endpointth, is_dns_endpoint)
                 
         # add the admin role so that we can do the managed kubernetes stuff for spark
         create_admin_binding(self.config.get("userName", None), kube_config_path)

--- a/python-clusters/attach-gke-cluster/cluster.py
+++ b/python-clusters/attach-gke-cluster/cluster.py
@@ -31,7 +31,7 @@ class MyCluster(Cluster):
         kube_config_path = os.path.join(os.getcwd(), 'kube_config')
         region_or_zone = clusters.region if is_regional else clusters.zone
         is_dns_endpont = self.config.get('isDnsEndpoint', False)
-        create_kube_config_file(clusters.project_id, cluster.name, is_regional, region_or_zone, kube_config_pa, is_dns_endpointth, is_dns_endpoint)
+        create_kube_config_file(clusters.project_id, cluster.name, is_regional, region_or_zone, kube_config_pa, is_dns_endpoint)
                 
         # add the admin role so that we can do the managed kubernetes stuff for spark
         create_admin_binding(self.config.get("userName", None), kube_config_path)

--- a/python-clusters/attach-gke-cluster/cluster.py
+++ b/python-clusters/attach-gke-cluster/cluster.py
@@ -30,7 +30,7 @@ class MyCluster(Cluster):
         # delegate the creation of the kube config file to gcloud to use the client go auth plugin
         kube_config_path = os.path.join(os.getcwd(), 'kube_config')
         region_or_zone = clusters.region if is_regional else clusters.zone
-        is_dns_endpont = self.config.get('isDnsEndpoint', False)
+        is_dns_endpoint = self.config.get('isDnsEndpoint', False)
         create_kube_config_file(clusters.project_id, cluster.name, is_regional, region_or_zone, kube_config_path, is_dns_endpoint)
                 
         # add the admin role so that we can do the managed kubernetes stuff for spark

--- a/python-clusters/attach-gke-cluster/cluster.py
+++ b/python-clusters/attach-gke-cluster/cluster.py
@@ -31,7 +31,7 @@ class MyCluster(Cluster):
         kube_config_path = os.path.join(os.getcwd(), 'kube_config')
         region_or_zone = clusters.region if is_regional else clusters.zone
         is_dns_endpont = self.config.get('isDnsEndpoint', False)
-        create_kube_config_file(clusters.project_id, cluster.name, is_regional, region_or_zone, kube_config_pa, is_dns_endpoint)
+        create_kube_config_file(clusters.project_id, cluster.name, is_regional, region_or_zone, kube_config_path, is_dns_endpoint)
                 
         # add the admin role so that we can do the managed kubernetes stuff for spark
         create_admin_binding(self.config.get("userName", None), kube_config_path)

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -124,7 +124,7 @@ def get_instance_service_account():
     return instance_active_sa
 
 
-def create_kube_config_file(project_id, cluster_id, is_cluster_regional, region_or_zone, kube_config_path):
+def create_kube_config_file(project_id, cluster_id, is_cluster_regional, region_or_zone, kube_config_path, is_dns_endpoint):
     """
     Delegate the creation of the kube config file to gke-gcloud-auth-plugin
     Starting with Kubernetes 1.26, the authentication to execute kubectl commands on Google clusters
@@ -155,6 +155,9 @@ def create_kube_config_file(project_id, cluster_id, is_cluster_regional, region_
     if project_id is not None and len(project_id) > 0:
         cmd.append("--project")
         cmd.append(project_id)
+
+    if is_dns_endpont:
+        cmd.append("--dns-endpoint")
         
     if is_cluster_regional:
         cmd.append("--region")

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -124,7 +124,7 @@ def get_instance_service_account():
     return instance_active_sa
 
 
-def create_kube_config_file(project_id, cluster_id, is_cluster_regional, region_or_zone, kube_config_path, is_dns_endpoint):
+def create_kube_config_file(project_id, cluster_id, is_cluster_regional, region_or_zone, kube_config_path, is_dns_endpoint=False):
     """
     Delegate the creation of the kube config file to gke-gcloud-auth-plugin
     Starting with Kubernetes 1.26, the authentication to execute kubectl commands on Google clusters
@@ -156,7 +156,7 @@ def create_kube_config_file(project_id, cluster_id, is_cluster_regional, region_
         cmd.append("--project")
         cmd.append(project_id)
 
-    if is_dns_endpont:
+    if is_dns_endpoint:
         cmd.append("--dns-endpoint")
         
     if is_cluster_regional:


### PR DESCRIPTION
[sc-226852]
This PR adds the option to use the DNS endpoint feature when attaching to an existing cluster.
When the GKE cluster is configured with both DNS and IP access, the gcloud utility defaults to using the IP. 
The IP might be unavailable if the cluster is exposed via private endpoints.
This adds the argument --dns-endpoint to the gcloud command so that the DNS endpoint is used.