### PR TITLE
Install NVIDIA driver daemonset only when required + bundle as fallback in case of issue downloading

### DIFF
--- a/python-lib/dku_kube/nvidia_utils.py
+++ b/python-lib/dku_kube/nvidia_utils.py
@@ -10,7 +10,7 @@ DAEMONSET_MANIFEST_URL = "https://raw.githubusercontent.com/GoogleCloudPlatform/
 def has_installer_daemonset(kube_config_path=None):
     env = os.environ.copy()
     if not _is_none_or_blank(kube_config_path):
-        logging.info("Setting kube_config path from KUBECONFIG env variable...")
+        logging.debug("Setting kube_config path from KUBECONFIG env variable...")
         env["KUBECONFIG"] = kube_config_path
         logging.info("Found KUBECONFIG={}".format(env["KUBECONFIG"]))
 
@@ -23,8 +23,10 @@ def create_installer_daemonset_if_needed(kube_config_path=None):
     """
     env = os.environ.copy()
     if not has_installer_daemonset(kube_config_path):
+        logging.info("Daemonset is not installed on the cluster. Installing.")
+
         if not _is_none_or_blank(kube_config_path):
-            logging.info("Setting kube_config path from KUBECONFIG env variable...")
+            logging.debug("Setting kube_config path from KUBECONFIG env variable...")
             env["KUBECONFIG"] = kube_config_path
             logging.info("Found KUBECONFIG={}".format(env["KUBECONFIG"]))
 
@@ -38,6 +40,7 @@ def create_installer_daemonset_if_needed(kube_config_path=None):
                 logging.error("No bundled daemonset definition found at '%s'. GPU driver must be installed manually." % daemonset_path)
                 return
 
+        logging.info("NVIDIA driver installer daemonset definition located at '%s'" % daemonset_path)
         subprocess.check_call(["kubectl", "apply", "-f", daemonset_path], env=env)
     else:
         logging.info("NVIDIA driver daemonset already present on the cluster. Skipping.")

--- a/python-lib/dku_kube/nvidia_utils.py
+++ b/python-lib/dku_kube/nvidia_utils.py
@@ -2,18 +2,42 @@ import os
 import logging
 import subprocess
 from dku_utils.access import _is_none_or_blank
+from dku_utils.static_resources import download_to_disk, get_static_resource_path
+from dku_kube.kubectl_command import run_with_timeout
 
 DAEMONSET_MANIFEST_URL = "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml"
 
-def create_installer_daemonset(kube_config_path=None):
-    """
-    Launch a pod on each node that will install the NVIDIA drivers.
-    """
-    
+def has_installer_daemonset(kube_config_path=None):
     env = os.environ.copy()
     if not _is_none_or_blank(kube_config_path):
         logging.info("Setting kube_config path from KUBECONFIG env variable...")
         env["KUBECONFIG"] = kube_config_path
         logging.info("Found KUBECONFIG={}".format(env["KUBECONFIG"]))
-    logging.info("Creating NVIDIA driver daemonset (only GPU-tainted nodes will be affected)")
-    subprocess.check_call(["kubectl", "apply", "-f", DAEMONSET_MANIFEST_URL], env=env)
+
+    out, err = run_with_timeout(["kubectl", "get", "daemonset", "nvidia-driver-installer", "-n", "kube-system", "--ignore-not-found"], env=env, timeout=5)
+    return len(out.strip()) > 0
+
+def create_installer_daemonset_if_needed(kube_config_path=None):
+    """
+    Launch a pod on each node that will install the NVIDIA drivers.
+    """
+    env = os.environ.copy()
+    if not has_installer_daemonset(kube_config_path):
+        if not _is_none_or_blank(kube_config_path):
+            logging.info("Setting kube_config path from KUBECONFIG env variable...")
+            env["KUBECONFIG"] = kube_config_path
+            logging.info("Found KUBECONFIG={}".format(env["KUBECONFIG"]))
+
+        logging.info("Creating NVIDIA driver daemonset (only GPU-tainted nodes will be affected)")
+        daemonset_path = download_to_disk(DAEMONSET_MANIFEST_URL, download_location="daemonset-preloaded.yaml")
+
+        if not daemonset_path:
+            logging.warning("Unable to retrieve daemonset from '%s', using bundled definition instead.")
+            daemonset_path = get_static_resource_path("daemonset-preloaded.yaml")
+            if not os.path.exists(daemonset_path):
+                logging.error("No bundled daemonset definition found at '%s'. GPU driver must be installed manually." % daemonset_path)
+                return
+
+        subprocess.check_call(["kubectl", "apply", "-f", daemonset_path], env=env)
+    else:
+        logging.info("NVIDIA driver daemonset already present on the cluster. Skipping.")

--- a/python-lib/dku_utils/static_resources.py
+++ b/python-lib/dku_utils/static_resources.py
@@ -1,0 +1,32 @@
+import logging
+import os
+import requests
+from dku_utils.access import _is_none_or_blank
+
+DEFAULT_HEADERS={"User-Agent": "DSS GKE Plugin"}
+
+def download_to_disk(url, download_location=None):
+    if _is_none_or_blank(url):
+        logging.error("URL '%s' is none or blank." % url)
+        return
+
+    if _is_none_or_blank(download_location):
+        local_path = url.split('/')[-1]
+    else:
+        local_path = download_location
+
+    r = requests.get(url, headers=DEFAULT_HEADERS)
+    if r.ok:
+        logging.debug("Successfully retrieved content from URL '%s'." % url)
+        logging.debug("Writing contents into path '%s'." % local_path)
+        with open(local_path, "w") as f:
+            f.write(r.text)
+
+        return os.path.abspath(local_path)
+    else:
+        logging.error("Retrieving the file from URL '%s' failed with status: %s %s" % (url, r.status_code, r.reason))
+        logging.error("Content of failed request: %s" % r.content)
+        logging.error("Unable to retrieve the contents from URL '%s'." % url)
+
+def get_static_resource_path(static_resource_filename):
+    return os.path.join(os.environ["DKU_CUSTOM_RESOURCE_FOLDER"], static_resource_filename)

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -2,7 +2,7 @@ import dataiku
 import json, logging, os
 from dku_google.clusters import Clusters
 from dku_utils.cluster import get_cluster_from_dss_cluster
-from dku_kube.nvidia_utils import create_installer_daemonset
+from dku_kube.nvidia_utils import create_installer_daemonset_if_needed
 from dataiku.runnables import Runnable
 
 
@@ -59,8 +59,9 @@ class MyRunnable(Runnable):
         create_op.wait_done()
         logging.info("Cluster node pool created")
 
-        # Launch NVIDIA driver installer daemonset (will only apply on tainted gpu nodes)
-        create_installer_daemonset(kube_config_path=kube_config_path)
+        # Launch NVIDIA driver installer daemonset (will only apply on tainted gpu nodes) if it's required.
+        if node_pool_config.get('withGpu', False): # GPUs are not supported on autopilot (says the GKE doc)
+            create_installer_daemonset_if_needed(kube_config_path=kube_config_path)
 
 
         return '<pre class="debug">%s</pre>' % json.dumps(node_pool.get_info(), indent=2)

--- a/resource/daemonset-preloaded.yaml
+++ b/resource/daemonset-preloaded.yaml
@@ -1,0 +1,141 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The Dockerfile and other source for this daemonset are in
+# https://cos.googlesource.com/cos/tools/+/refs/heads/master/src/cmd/cos_gpu_installer/
+#
+# This is the same as ../../daemonset.yaml except that it assumes that the
+# docker image is present on the node instead of downloading from GCR. This
+# allows easier upgrades because GKE can preload the correct image on the
+# node and the daemonset can just use that image.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-driver-installer
+  namespace: kube-system
+  labels:
+    k8s-app: nvidia-driver-installer
+spec:
+  selector:
+    matchLabels:
+      k8s-app: nvidia-driver-installer
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nvidia-driver-installer
+        k8s-app: nvidia-driver-installer
+    spec:
+      priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-accelerator
+                operator: Exists
+              - key: cloud.google.com/gke-gpu-driver-version
+                operator: DoesNotExist
+      tolerations:
+      - operator: "Exists"
+      hostNetwork: true
+      hostPID: true
+      volumes:
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: vulkan-icd-mount
+        hostPath:
+          path: /home/kubernetes/bin/nvidia/vulkan/icd.d
+      - name: nvidia-install-dir-host
+        hostPath:
+          path: /home/kubernetes/bin/nvidia
+      - name: root-mount
+        hostPath:
+          path: /
+      - name: cos-tools
+        hostPath:
+          path: /var/lib/cos-tools
+      - name: nvidia-config
+        hostPath:
+          path: /etc/nvidia
+      initContainers:
+      - image: "cos-nvidia-installer:fixed"
+        imagePullPolicy: Never
+        name: nvidia-driver-installer
+        resources:
+          requests:
+            cpu: 150m
+        securityContext:
+          privileged: true
+        env:
+          - name: NVIDIA_INSTALL_DIR_HOST
+            value: /home/kubernetes/bin/nvidia
+          - name: NVIDIA_INSTALL_DIR_CONTAINER
+            value: /usr/local/nvidia
+          - name: VULKAN_ICD_DIR_HOST
+            value: /home/kubernetes/bin/nvidia/vulkan/icd.d
+          - name: VULKAN_ICD_DIR_CONTAINER
+            value: /etc/vulkan/icd.d
+          - name: ROOT_MOUNT_DIR
+            value: /root
+          - name: COS_TOOLS_DIR_HOST
+            value: /var/lib/cos-tools
+          - name: COS_TOOLS_DIR_CONTAINER
+            value: /build/cos-tools
+        volumeMounts:
+        - name: nvidia-install-dir-host
+          mountPath: /usr/local/nvidia
+        - name: vulkan-icd-mount
+          mountPath: /etc/vulkan/icd.d
+        - name: dev
+          mountPath: /dev
+        - name: root-mount
+          mountPath: /root
+        - name: cos-tools
+          mountPath: /build/cos-tools
+        command:
+        - bash
+        - -c
+        - |
+          echo "Checking for existing GPU driver modules"
+          if lsmod | grep nvidia; then
+            echo "GPU driver is already installed, the installed version may or may not be the driver version being tried to install, skipping installation"
+            exit 0
+          else
+            echo "No GPU driver module detected, installing now"
+            /cos-gpu-installer install || exit 1
+          fi
+      - image: "gcr.io/gke-release/nvidia-partition-gpu@sha256:116be6b7335c1d34366223b9a3780fe80d862fcf06cd2c580426fdc1697af693"
+        name: partition-gpus
+        env:
+          - name: LD_LIBRARY_PATH
+            value: /usr/local/nvidia/lib64
+        resources:
+          requests:
+            cpu: 150m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: nvidia-install-dir-host
+          mountPath: /usr/local/nvidia
+        - name: dev
+          mountPath: /dev
+        - name: nvidia-config
+          mountPath: /etc/nvidia
+      containers:
+      - image: "gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830"
+        name: pause


### PR DESCRIPTION
[sc-210880]

When creating a GKE cluster, we always install the NVIDIA driver installer daemonset, even if the cluster has no node groups with GPUs attached.

Now we only install when required (GPU attached + daemonset not already present) and we also bundle the daemonset definition so that if we fail to download it from GitHub, we can still install it.
