### PR TITLE
Better display output for shell-level commands

### DIFF
--- a/python-clusters/attach-gke-cluster/cluster.json
+++ b/python-clusters/attach-gke-cluster/cluster.json
@@ -34,6 +34,39 @@
             "description": "If not the same as the gcloud user",
             "type": "STRING",
             "mandatory" : false
+        },
+        {
+            "name": "logLevel",
+            "label": "Log level",
+            "type": "SELECT",
+            "selectChoices": [
+                {
+                    "value": "NOTSET",
+                    "label": "NotSet"
+                },
+                {
+                    "value": "DEBUG",
+                    "label": "Debug"
+                },
+                {
+                    "value": "INFO",
+                    "label": "Info"
+                },
+                {
+                    "value": "WARNING",
+                    "label": "Warning"
+                },
+                {
+                    "value": "ERROR",
+                    "label": "Error"
+                },
+                {
+                    "value": "CRITICAL",
+                    "label": "Critical"
+                }
+            ],
+            "mandatory": false,
+            "defaultValue": "INFO"
         }
     ]
 }

--- a/python-clusters/attach-gke-cluster/cluster.py
+++ b/python-clusters/attach-gke-cluster/cluster.py
@@ -19,6 +19,8 @@ class MyCluster(Cluster):
         self.global_settings = global_settings
         
     def start(self):
+        logging.getLogger().setLevel(self.config.get('logLevel', 'INFO'))
+
         # retrieve the cluster info from GKE
         # this will fail if the cluster doesn't exist, but the API message is enough
         clusters = get_cluster_from_connection_info(self.config['connectionInfo'], self.plugin_config['connectionInfo'])

--- a/python-clusters/create-gke-cluster/cluster.json
+++ b/python-clusters/create-gke-cluster/cluster.json
@@ -177,6 +177,39 @@
             "description": "Additional settings for the cluster creation call, as JSON",
             "type": "TEXTAREA",
             "mandatory": false
+        },
+        {
+            "name": "logLevel",
+            "label": "Log level",
+            "type": "SELECT",
+            "selectChoices": [
+                {
+                    "value": "NOTSET",
+                    "label": "NotSet"
+                },
+                {
+                    "value": "DEBUG",
+                    "label": "Debug"
+                },
+                {
+                    "value": "INFO",
+                    "label": "Info"
+                },
+                {
+                    "value": "WARNING",
+                    "label": "Warning"
+                },
+                {
+                    "value": "ERROR",
+                    "label": "Error"
+                },
+                {
+                    "value": "CRITICAL",
+                    "label": "Critical"
+                }
+            ],
+            "mandatory": false,
+            "defaultValue": "INFO"
         }
     ]
 }

--- a/python-clusters/create-gke-cluster/cluster.py
+++ b/python-clusters/create-gke-cluster/cluster.py
@@ -21,6 +21,8 @@ class MyCluster(Cluster):
         self.global_settings = global_settings
         
     def start(self):
+        logging.getLogger().setLevel(self.config.get('logLevel', 'INFO'))
+
         # build the create cluster request
         clusters = get_cluster_from_connection_info(self.config['connectionInfo'], self.plugin_config['connectionInfo'])
         

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -58,7 +58,7 @@ def _run_cmd(cmd=None, **kwargs):
         raise Exception(err)
 
     cmd_out = out.rstrip()
-    logging.info(f"'{cmd_pretty}' output: {cmd_out}")
+    logging.debug(f"'{cmd_pretty}' output: {cmd_out}")
     return cmd_out
 
 

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -45,7 +45,8 @@ def _run_cmd(cmd=None, **kwargs):
     Run command via subprocess. Clean retrieval and throw of error message if fails. Trims any trailing space.
     """
 
-    logging.info("Running CMD {}".format(cmd))
+    cmd_pretty = ' '.join(cmd)
+    logging.info("Running CMD: {}".format(cmd_pretty))
     p = subprocess.Popen(cmd,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
@@ -55,7 +56,10 @@ def _run_cmd(cmd=None, **kwargs):
     rv = p.wait()
     if rv != 0:
         raise Exception(err)
-    return out.rstrip()
+
+    cmd_out = out.rstrip()
+    logging.info(f"'{cmd_pretty}' output: {cmd_out}")
+    return cmd_out
 
 
 def get_instance_info():

--- a/python-lib/dku_google/gcloud.py
+++ b/python-lib/dku_google/gcloud.py
@@ -58,7 +58,7 @@ def _run_cmd(cmd=None, **kwargs):
         raise Exception(err)
 
     cmd_out = out.rstrip()
-    logging.debug(f"'{cmd_pretty}' output: {cmd_out}")
+    logging.debug("'{}' output: {}".format(cmd_pretty, cmd_out))
     return cmd_out
 
 

--- a/python-runnables/add-node-pool/runnable.json
+++ b/python-runnables/add-node-pool/runnable.json
@@ -40,6 +40,39 @@
             "type": "PRESET",
             "parameterSetId" : "node-pool-request",
             "mandatory" : true
+        },
+        {
+            "name": "logLevel",
+            "label": "Log level",
+            "type": "SELECT",
+            "selectChoices": [
+                {
+                    "value": "NOTSET",
+                    "label": "NotSet"
+                },
+                {
+                    "value": "DEBUG",
+                    "label": "Debug"
+                },
+                {
+                    "value": "INFO",
+                    "label": "Info"
+                },
+                {
+                    "value": "WARNING",
+                    "label": "Warning"
+                },
+                {
+                    "value": "ERROR",
+                    "label": "Error"
+                },
+                {
+                    "value": "CRITICAL",
+                    "label": "Critical"
+                }
+            ],
+            "mandatory": false,
+            "defaultValue": "INFO"
         }
     ]
 }

--- a/python-runnables/add-node-pool/runnable.py
+++ b/python-runnables/add-node-pool/runnable.py
@@ -17,6 +17,7 @@ class MyRunnable(Runnable):
         return None
 
     def run(self, progress_callback):
+        logging.getLogger().setLevel(self.config.get('logLevel', 'INFO'))
         cluster_data, cluster, dss_cluster_settings, dss_cluster_config = get_cluster_from_dss_cluster(self.config['clusterId'])
         
         if cluster_data.get("cluster", {}).get("autopilot", {}).get("enabled", False):


### PR DESCRIPTION
This commit updates the shell command wrapper to:
1. Display the commands being called in a string-friendly way (i.e. not as an array anymore). This makes it easier to copy-paste for debugging.
2. display the output of each command being called. Again this is to help in debugging.
[sc-226848]