### PR TITLE
Configure Google authentication environment to disable metadata-server mTLS

### DIFF
--- a/python-lib/dku_google/clusters.py
+++ b/python-lib/dku_google/clusters.py
@@ -10,6 +10,14 @@ import logging
 
 from .operations import Operation
 
+GCE_METADATA_MTLS_MODE_ENV = "GCE_METADATA_MTLS_MODE"
+
+
+def _configure_google_auth_env():
+    # Only disable metadata-server mTLS. This avoids forcing broader mTLS
+    # behavior changes for other Google API clients in the same process.
+    os.environ.setdefault(GCE_METADATA_MTLS_MODE_ENV, "none")
+
 class NodePoolBuilder(object):
     def __init__(self, cluster_builder):
         self.cluster_builder = cluster_builder
@@ -576,6 +584,7 @@ class Cluster(object):
 class Clusters(object):
     def __init__(self, project_id, zone, region, credentials=None):
         logging.info("Connect using project_id=%s zone=%s region=%s credentials=%s" % (project_id, zone, region, credentials))
+        _configure_google_auth_env()
         instance_info = get_instance_info()
         if _is_none_or_blank(project_id):
             default_project = instance_info["project"]


### PR DESCRIPTION
## Summary

Prevent GKE cluster startup from failing on hosts where `google-auth` switches metadata lookup to the HTTPS+mTLS endpoint.

## Change

Set `GCE_METADATA_MTLS_MODE=none` in `python-lib/dku_google/clusters.py` before Google clients are initialised.

## Problem

On some hosts, credential refresh attempts against:

`https://metadata.google.internal/...`

fail with SSL verification errors because the metadata mTLS certificate chain is not available locally. When that happens, cluster startup fails before the GKE API request can be authenticated.

## Why this fix

This keeps the change limited to metadata-server behaviour for this plugin process.

We intentionally do not set `GOOGLE_API_USE_CLIENT_CERTIFICATE=false`, since that can affect mTLS behavior more broadly for other Google API calls.

## Validation

- Re-run GKE cluster creation on a host that previously failed with metadata HTTPS certificate errors
- Confirm the metadata SSL failure no longer appears
- Confirm cluster startup proceeds normally

## Risk

Low. The change only affects how metadata credentials are fetched.
